### PR TITLE
Exports to StrapiQueryBuilder and StrapiFilterBuilder classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,5 @@ export type {
 } from './lib/types/base';
 export type { SignInCredentials, SignUpCredentials } from './lib/types/auth';
 export type { StrapiImage } from './lib/types/image';
+export * from './lib/strapi-query-builder'
+export * from './lib/strapi-filter-builder'


### PR DESCRIPTION
There are a few problems with type inference when trying to export an instance of `StrapiQueryBuilder`

```ts
export const Orders = strapi.from<Order>('orders');
//           ^ ts(4063) - see https://github.com/microsoft/TypeScript/issues/17293
```

One way to export is to create a type that uses `ReturnType` to infer `.from` method return.
```ts
const strapi = createClient(/* options */);

export type QueryBuilder<T> = ReturnType<typeof strapi.from<T>>;

export const Orders: QueryBuilder<Order> = strapi.from('orders');
```

If the `StrapiQueryBuilder` is exported, this workaround does not need to exist, and there are a few more gains if so (like typedoc inference when using it)

